### PR TITLE
chore: promote react-spring to version 0.0.12

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -3,5 +3,6 @@ helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
 - path: helmfiles/jx-staging/helmfile.yaml
+- path: helmfiles/jx-production/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-production
+repositories:
+- name: dev
+  url: https://iMckify.github.io/pipeline-config-charts/
+releases:
+- chart: dev/react-spring
+  version: 0.0.12
+  name: react-spring
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.12

### Chores

* release 0.0.12 (jenkins-x-bot)
* add variables (jenkins-x-bot)
