### PR TITLE
chore: promote react-spring to version 0.0.18

### DIFF
--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.14"
+    chart: "react-spring-0.0.18"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.14"
+        image: "10.97.57.112/imckify/react-spring:0.0.18"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.14
+          value: 0.0.18
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.14"
+    chart: "react-spring-0.0.18"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: 2fae1c17ae8858f9cfa0b45a9d3274cd742ec25e190cb7b9fe2d2151ba621d6c
+        checksum/secret: 05d4d64851c728e1129cd84bf715bf5a6f22b65c08cbfaf1584df2d6892f494e
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://iMckify.github.io/pipeline-config-charts/
 releases:
 - chart: dev/react-spring
-  version: 0.0.14
+  version: 0.0.18
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.18

### Chores

* release 0.0.18 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* debug wolfi 5 (iMckify)
