### PR TITLE
chore: promote react-spring to version 0.0.24

### DIFF
--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.23"
+    chart: "react-spring-0.0.24"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.23"
+        image: "10.97.57.112/imckify/react-spring:0.0.24"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.23
+          value: 0.0.24
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.23"
+    chart: "react-spring-0.0.24"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: 5076371eb05c5de09dc1bae51959326ff171625aba0536189e32ff1b1b7b043f
+        checksum/secret: dbc490be08ac1595c16285893636570aac1ec36e532b4484dbb2c1db66992209
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://iMckify.github.io/pipeline-config-charts/
 releases:
 - chart: dev/react-spring
-  version: 0.0.23
+  version: 0.0.24
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.24

### Chores

* release 0.0.24 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* test4 (iMckify)
