### PR TITLE
chore: promote react-spring to version 0.0.26

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -23,6 +23,15 @@ spec:
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-env-pr.yaml@versionStream
           resources: {}
+        - name: list-bucketrepo-charts
+          image: alpine:latest
+          resources: { }
+          script: |
+            #!/bin/sh
+            apk update
+            apk add curl
+            echo "Listing charts from bucketrepo.jx:"
+            curl -s http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/index.yaml
         - name: make-pr
           resources:
             # override requests for the pod here

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -1,11 +1,9 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
-metadata:
-  annotations:
-    internal.kpt.dev/upstream-identifier: tekton.dev|PipelineRun|default|pullrequest
-    lighthouse.jenkins-x.io/prependStepsURL: https://raw.githubusercontent.com/jenkins-x/jx3-pipeline-catalog/839765fb594490586e51b25e12b93609441235f8/tasks/git-clone/git-clone-pr.yaml
-  creationTimestamp: null
+metadata: # kpt-merge: /pullrequest
   name: pullrequest
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'tekton.dev|PipelineRun|default|pullrequest'
 spec:
   pipelineSpec:
     tasks:
@@ -13,22 +11,21 @@ spec:
       resources: {}
       taskSpec:
         metadata: {}
-        spec: null
         stepTemplate:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/environment/pullrequest.yaml@versionStream
           name: ""
           resources:
+            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 512Mi
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-env-pr.yaml@versionStream
-          name: ""
           resources: {}
-        - image: alpine:latest
-          name: list-bucketrepo-charts
-          resources: {}
+        - name: list-bucketrepo-charts
+          image: alpine:latest
+          resources: { }
           script: |
             #!/bin/sh
             apk update
@@ -37,8 +34,9 @@ spec:
             curl -s http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/index.yaml
         - name: make-pr
           resources:
+            # override requests for the pod here
             requests:
-              cpu: 100m
+              cpu: 0.1
               memory: 128Mi
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -1,9 +1,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
-metadata: # kpt-merge: /pullrequest
-  name: pullrequest
+metadata:
   annotations:
-    internal.kpt.dev/upstream-identifier: 'tekton.dev|PipelineRun|default|pullrequest'
+    internal.kpt.dev/upstream-identifier: tekton.dev|PipelineRun|default|pullrequest
+    lighthouse.jenkins-x.io/prependStepsURL: https://raw.githubusercontent.com/jenkins-x/jx3-pipeline-catalog/839765fb594490586e51b25e12b93609441235f8/tasks/git-clone/git-clone-pr.yaml
+  creationTimestamp: null
+  name: pullrequest
 spec:
   pipelineSpec:
     tasks:
@@ -11,21 +13,22 @@ spec:
       resources: {}
       taskSpec:
         metadata: {}
+        spec: null
         stepTemplate:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/environment/pullrequest.yaml@versionStream
           name: ""
           resources:
-            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 512Mi
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-env-pr.yaml@versionStream
+          name: ""
           resources: {}
-        - name: list-bucketrepo-charts
-          image: alpine:latest
-          resources: { }
+        - image: alpine:latest
+          name: list-bucketrepo-charts
+          resources: {}
           script: |
             #!/bin/sh
             apk update
@@ -34,9 +37,8 @@ spec:
             curl -s http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/index.yaml
         - name: make-pr
           resources:
-            # override requests for the pod here
             requests:
-              cpu: 0.1
+              cpu: 100m
               memory: 128Mi
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -1,9 +1,11 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
-metadata: # kpt-merge: /release
-  name: release
+metadata:
   annotations:
-    internal.kpt.dev/upstream-identifier: 'tekton.dev|PipelineRun|default|release'
+    internal.kpt.dev/upstream-identifier: tekton.dev|PipelineRun|default|release
+    lighthouse.jenkins-x.io/prependStepsURL: https://raw.githubusercontent.com/jenkins-x/jx3-pipeline-catalog/839765fb594490586e51b25e12b93609441235f8/tasks/git-clone/git-clone.yaml
+  creationTimestamp: null
+  name: release
 spec:
   pipelineSpec:
     tasks:
@@ -11,11 +13,11 @@ spec:
       resources: {}
       taskSpec:
         metadata: {}
+        spec: null
         stepTemplate:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/environment/release.yaml@versionStream
           name: ""
           resources:
-            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 256Mi
@@ -26,9 +28,8 @@ spec:
           resources: {}
         - name: admin-log
           resources:
-            # override requests for the pod here
             requests:
-              cpu: 0.1
+              cpu: 100m
               memory: 128Mi
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -1,11 +1,9 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
-metadata:
-  annotations:
-    internal.kpt.dev/upstream-identifier: tekton.dev|PipelineRun|default|release
-    lighthouse.jenkins-x.io/prependStepsURL: https://raw.githubusercontent.com/jenkins-x/jx3-pipeline-catalog/839765fb594490586e51b25e12b93609441235f8/tasks/git-clone/git-clone.yaml
-  creationTimestamp: null
+metadata: # kpt-merge: /release
   name: release
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'tekton.dev|PipelineRun|default|release'
 spec:
   pipelineSpec:
     tasks:
@@ -13,11 +11,11 @@ spec:
       resources: {}
       taskSpec:
         metadata: {}
-        spec: null
         stepTemplate:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/environment/release.yaml@versionStream
           name: ""
           resources:
+            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 256Mi
@@ -28,8 +26,9 @@ spec:
           resources: {}
         - name: admin-log
           resources:
+            # override requests for the pod here
             requests:
-              cpu: 100m
+              cpu: 0.1
               memory: 128Mi
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,8 +6,6 @@ environments:
 namespace: jx-staging
 repositories:
 - name: dev
-  url: https://iMckify.github.io/pipeline-config-charts/
-- name: dev2
   url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,9 +7,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://iMckify.github.io/pipeline-config-charts/
+- name: dev2
+  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
-  version: 0.0.25
+  version: 0.0.26
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx/bucketrepo-values.yaml
+++ b/helmfiles/jx/bucketrepo-values.yaml
@@ -1,0 +1,8 @@
+# set volume for bucketrepo pod
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 5Gi
+  existingClaim: ""
+  storageClass: ""
+  hostPath: /home/rokas/volumes/bucketrepo

--- a/helmfiles/jx/helmfile.yaml
+++ b/helmfiles/jx/helmfile.yaml
@@ -41,7 +41,7 @@ releases:
   - ../../versionStream/charts/jxgh/lighthouse/values.yaml.gotmpl
   - jx-values.yaml
 - chart: jxgh/bucketrepo
-  version: 0.6.0
+  version: 0.6.1
   name: bucketrepo
   values:
   - ../../versionStream/charts/jxgh/bucketrepo/values.yaml.gotmpl

--- a/helmfiles/jx/helmfile.yaml
+++ b/helmfiles/jx/helmfile.yaml
@@ -46,6 +46,7 @@ releases:
   values:
   - ../../versionStream/charts/jxgh/bucketrepo/values.yaml.gotmpl
   - jx-values.yaml
+  - ./bucketrepo-values.yaml
 - chart: twuni/docker-registry
   name: docker-registry
   values:


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.26

### Chores

* release 0.0.26 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* in pr job (iMckify)
* 8 (iMckify)
* 7 (iMckify)
* 6 (iMckify)
* Revert "Revert "GH_ACCESS_TOKEN"" (iMckify)
* 5 (iMckify)
* Revert "GH_ACCESS_TOKEN" (iMckify)
* GH_ACCESS_TOKEN 4 (iMckify)
* GH_ACCESS_TOKEN 3 (iMckify)
* GH_ACCESS_TOKEN 2 (iMckify)
* GH_ACCESS_TOKEN (iMckify)
* ui (iMckify)
