### PR TITLE
chore: promote react-spring to version 0.0.27

### DIFF
--- a/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.25"
+    chart: "react-spring-0.0.27"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.25"
+        image: "10.97.57.112/imckify/react-spring:0.0.27"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.25
+          value: 0.0.27
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.25"
+    chart: "react-spring-0.0.27"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.25"
+    chart: "react-spring-0.0.27"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.25"
+        image: "10.97.57.112/imckify/react-spring:0.0.27"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.25
+          value: 0.0.27
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.25"
+    chart: "react-spring-0.0.27"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/bucketrepo/bucketrepo-bucketrepo-deploy.yaml
+++ b/config-root/namespaces/jx/bucketrepo/bucketrepo-bucketrepo-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: bucketrepo-bucketrepo
   labels:
     draft: draft-app
-    chart: "bucketrepo-0.6.0"
+    chart: "bucketrepo-0.6.1"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'bucketrepo'
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: bucketrepo
-        image: "ghcr.io/jenkins-x/bucketrepo:0.6.0"
+        image: "ghcr.io/jenkins-x/bucketrepo:0.6.1"
         imagePullPolicy: IfNotPresent
         args:
         - "-config-path=/config"

--- a/config-root/namespaces/jx/bucketrepo/bucketrepo-bucketrepo-sa.yaml
+++ b/config-root/namespaces/jx/bucketrepo/bucketrepo-bucketrepo-sa.yaml
@@ -5,7 +5,7 @@ metadata:
   name: bucketrepo-bucketrepo
   labels:
     app: bucketrepo-bucketrepo
-    chart: "bucketrepo-0.6.0"
+    chart: "bucketrepo-0.6.1"
     release: bucketrepo
     heritage: Helm
     gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx/bucketrepo/bucketrepo-svc.yaml
+++ b/config-root/namespaces/jx/bucketrepo/bucketrepo-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: bucketrepo
   labels:
-    chart: "bucketrepo-0.6.0"
+    chart: "bucketrepo-0.6.1"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: f7b233ab5f639c6f96b770cc45a317c913dac7f9d1599b9921ec43bf1335c473
+        checksum/secret: f992bc353e348ca1472e3345127ef1991ba28dc8e7f71b368f239057b1b2f84d
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://iMckify.github.io/pipeline-config-charts/
 releases:
 - chart: dev/react-spring
-  version: 0.0.25
+  version: 0.0.27
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,8 +7,6 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
-- name: dev2
-  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
   version: 0.0.27

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,9 +7,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
+- name: dev2
+  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
-  version: 0.0.26
+  version: 0.0.27
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.27

### Chores

* release 0.0.27 (jenkins-x-bot)
* add variables (jenkins-x-bot)
