### PR TITLE
chore: promote react-spring to version 0.0.31

### DIFF
--- a/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.27"
+    chart: "react-spring-0.0.31"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.27"
+        image: "10.97.57.112/imckify/react-spring:0.0.31"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.27
+          value: 0.0.31
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.27"
+    chart: "react-spring-0.0.31"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.27"
+    chart: "react-spring-0.0.31"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.27"
+        image: "10.97.57.112/imckify/react-spring:0.0.31"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.27
+          value: 0.0.31
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.27"
+    chart: "react-spring-0.0.31"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/bucketrepo/bucketrepo-bucketrepo-deploy.yaml
+++ b/config-root/namespaces/jx/bucketrepo/bucketrepo-bucketrepo-deploy.yaml
@@ -1,3 +1,4 @@
+# Source: bucketrepo/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,39 +25,46 @@ spec:
         checksum/config: "e4eb9e4600079b6269234f92d4eb0772e0537e685f847544b7fc810254517ae0"
     spec:
       containers:
-        - name: bucketrepo
-          image: "ghcr.io/jenkins-x/bucketrepo:0.6.1"
-          imagePullPolicy: IfNotPresent
-          args:
-            - "-config-path=/config"
-            - "-log-level=info"
-          env:
-          ports:
-            - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          volumeMounts:
-            - name: config
-              mountPath: /config
-              readOnly: true
+      - name: bucketrepo
+        image: "ghcr.io/jenkins-x/bucketrepo:0.6.1"
+        imagePullPolicy: IfNotPresent
+        args:
+        - "-config-path=/config"
+        - "-log-level=info"
+        env:
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+        resources:
+          limits:
+            cpu: "1"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
       securityContext:
         fsGroup: 65534
       terminationGracePeriodSeconds: 10
       serviceAccountName: bucketrepo-bucketrepo
       volumes:
-        - name: config
-          secret:
-            secretName: bucketrepo-config
+      - name: config
+        secret:
+          secretName: bucketrepo-config

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: 631c2d476eb8d66447ce0578119db14b02590aabba40c98572dfecca21674124
+        checksum/secret: 1a10d6cb83df10b5d2aaf744ff64d353587dac256a3780a42e5cf375de7357af
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
 releases:
 - chart: dev/react-spring
-  version: 0.0.29
+  version: 0.0.31
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
 releases:
 - chart: dev/react-spring
-  version: 0.0.29
+  version: 0.0.31
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.31

### Chores

* release 0.0.31 (jenkins-x-bot)
* add variables (jenkins-x-bot)
