### PR TITLE
chore: promote react-spring to version 0.0.46

### DIFF
--- a/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.31"
+    chart: "react-spring-0.0.46"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.31"
+        image: "10.97.57.112/imckify/react-spring:0.0.46"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.31
+          value: 0.0.46
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.31"
+    chart: "react-spring-0.0.46"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.32"
+    chart: "react-spring-0.0.46"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.32"
+        image: "10.97.57.112/imckify/react-spring:0.0.46"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.32
+          value: 0.0.46
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.32"
+    chart: "react-spring-0.0.46"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: 38b6e36435b3cadab6122469f5f2cb23f7483c293e413dd3db239fc7223616cd
+        checksum/secret: 2c51e1cc3dfc336b45ccb3607b9195e0b24d52785d78d8b31b1f3cc0ea9cbe10
     spec:
       securityContext:
         fsGroup: 1000

--- a/config-root/namespaces/jx/docker-registry/docker-registry-ingress.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-ingress.yaml
@@ -12,7 +12,6 @@ metadata:
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'docker-registry'
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"  # Ensure HTTP -> HTTPS redirect
 spec:
   ingressClassName: nginx
   rules:
@@ -26,7 +25,3 @@ spec:
             name: docker-registry
             port:
               number: 80
-  tls:
-    - hosts:
-        - docker-registry-jx.192.168.49.2.nip.io
-      secretName: docker-registry-tls

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
 releases:
 - chart: dev/react-spring
-  version: 0.0.31
+  version: 0.0.46
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,9 +7,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
+- name: dev2
+  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
-  version: 0.0.32
+  version: 0.0.46
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,8 +7,6 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
-- name: dev2
-  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
   version: 0.0.46


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.46

### Chores

* release 0.0.46 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* fixing bootjob 74 helm chart 0.0.32 not found (iMckify)
* rollback release pipeline (iMckify)
