### PR TITLE
chore: promote react-spring to version 0.0.47

### DIFF
--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.46"
+    chart: "react-spring-0.0.47"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.46"
+        image: "10.97.57.112/imckify/react-spring:0.0.47"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.46
+          value: 0.0.47
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.46"
+    chart: "react-spring-0.0.47"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: e1e8baba38fddcfc7d22edfd8dc871a1f9e38d04a10a74d7ea267b4321cd5047
+        checksum/secret: e803a42eb017e499e7bbb26b23b3efff86ccbb31b07b712c77c3e57d539d04bb
     spec:
       securityContext:
         fsGroup: 1000

--- a/config-root/namespaces/jx/docker-registry/docker-registry-ingress.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-ingress.yaml
@@ -9,9 +9,14 @@ metadata:
     chart: docker-registry-2.2.3
     release: docker-registry
     heritage: Helm
+    app: docker-registry
+    chart: docker-registry-2.2.3
     gitops.jenkins-x.io/pipeline: 'namespaces'
+    heritage: Helm
+    release: docker-registry
   annotations:
-    meta.helm.sh/release-name: 'docker-registry'
+    meta.helm.sh/release-name: "docker-registry"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   ingressClassName: nginx
   rules:
@@ -25,3 +30,7 @@ spec:
             name: docker-registry
             port:
               number: 80
+  tls:
+  - hosts:
+    - docker-registry-jx.192.168.49.2.nip.io
+    secretName: docker-registry-tls

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,9 +7,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
+- name: dev2
+  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
-  version: 0.0.46
+  version: 0.0.47
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,8 +7,6 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
-- name: dev2
-  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
   version: 0.0.47


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.47

### Chores

* release 0.0.47 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* trigger release (iMckify)
