### PR TITLE
chore: promote react-spring to version 0.0.50

### DIFF
--- a/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.46"
+    chart: "react-spring-0.0.50"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.46"
+        image: "10.97.57.112/imckify/react-spring:0.0.50"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.46
+          value: 0.0.50
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.46"
+    chart: "react-spring-0.0.50"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.47"
+    chart: "react-spring-0.0.50"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.47"
+        image: "10.97.57.112/imckify/react-spring:0.0.50"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.47
+          value: 0.0.50
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.47"
+    chart: "react-spring-0.0.50"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: d73fc74de73c0ac094c5c705be186c6cf7f4e46ad335b1cca17da78bf52ee3ac
+        checksum/secret: 0c98c0b5938bfa2431a0b433dc29045163bde5aaf41c8486b1ab31ed1ecf6fa1
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
 releases:
 - chart: dev/react-spring
-  version: 0.0.46
+  version: 0.0.50
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,9 +7,11 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
+- name: dev2
+  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
-  version: 0.0.47
+  version: 0.0.50
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,8 +7,6 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
-- name: dev2
-  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
   version: 0.0.50


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.50

### Chores

* release 0.0.50 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* trigger release 3 (iMckify)
* trigger release 2 (iMckify)
* Revert "release using oci push" (iMckify)
