### PR TITLE
chore: promote react-spring to version 0.0.50

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -7,9 +7,11 @@ namespace: jx-production
 repositories:
 - name: dev
   url: http://bucketrepo-jx.192.168.49.2.nip.io/bucketrepo/charts
+- name: dev2
+  url: http://bucketrepo-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
-  version: 0.0.46
+  version: 0.0.50
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.50

### Chores

* release 0.0.50 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* trigger release 3 (iMckify)
* trigger release 2 (iMckify)
* Revert "release using oci push" (iMckify)
