### PR TITLE
chore: promote react-spring to version 0.0.53

### DIFF
--- a/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.50"
+    chart: "react-spring-0.0.25"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.50"
+        image: "10.97.57.112/imckify/react-spring:0.0.25"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.50
+          value: 0.0.25
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.50"
+    chart: "react-spring-0.0.25"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.52"
+    chart: "react-spring-0.0.53"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.52"
+        image: "10.97.57.112/imckify/react-spring:0.0.53"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.52
+          value: 0.0.53
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.52"
+    chart: "react-spring-0.0.53"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: 5f77f2bb71460588574b15c75c5f06cd132d2892d2b06fa8a8abde0fcea56869
+        checksum/secret: 5986c24b3934bab88f8eb42491751bf102159294f713a7fa00fb1d261356bcdc
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://iMckify.github.io/pipeline-config-charts/
 releases:
 - chart: dev/react-spring
-  version: 0.0.52
+  version: 0.0.25
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-production/jx-values.yaml
+++ b/helmfiles/jx-production/jx-values.yaml
@@ -21,7 +21,8 @@ jxRequirements:
     enabled: false
     schedule: ""
   cluster:
-    chartRepository: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+    chartKind: pages
+    chartRepository: https://github.com/iMckify/pipeline-config-charts.git
     clusterName: kind
     devEnvApprovers:
     - todo

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://iMckify.github.io/pipeline-config-charts/
 releases:
 - chart: dev/react-spring
-  version: 0.0.52
+  version: 0.0.53
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/jx-values.yaml
+++ b/helmfiles/jx-staging/jx-values.yaml
@@ -21,7 +21,8 @@ jxRequirements:
     enabled: false
     schedule: ""
   cluster:
-    chartRepository: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+    chartKind: pages
+    chartRepository: https://github.com/iMckify/pipeline-config-charts.git
     clusterName: kind
     devEnvApprovers:
     - todo

--- a/helmfiles/jx/jx-values.yaml
+++ b/helmfiles/jx/jx-values.yaml
@@ -21,7 +21,8 @@ jxRequirements:
     enabled: false
     schedule: ""
   cluster:
-    chartRepository: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+    chartKind: pages
+    chartRepository: https://github.com/iMckify/pipeline-config-charts.git
     clusterName: kind
     devEnvApprovers:
     - todo

--- a/helmfiles/tekton-pipelines/jx-values.yaml
+++ b/helmfiles/tekton-pipelines/jx-values.yaml
@@ -21,7 +21,8 @@ jxRequirements:
     enabled: false
     schedule: ""
   cluster:
-    chartRepository: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+    chartKind: pages
+    chartRepository: https://github.com/iMckify/pipeline-config-charts.git
     clusterName: kind
     devEnvApprovers:
     - todo


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.53

### Chores

* release 0.0.53 (jenkins-x-bot)
* add variables (jenkins-x-bot)
