### PR TITLE
chore: promote react-spring to version 0.0.74

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -1,9 +1,10 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
-metadata: # kpt-merge: /pullrequest
-  name: pullrequest
+metadata:
   annotations:
-    internal.kpt.dev/upstream-identifier: 'tekton.dev|PipelineRun|default|pullrequest'
+    internal.kpt.dev/upstream-identifier: tekton.dev|PipelineRun|default|pullrequest
+  creationTimestamp: null
+  name: pullrequest
 spec:
   pipelineSpec:
     tasks:
@@ -11,24 +12,33 @@ spec:
       resources: {}
       taskSpec:
         metadata: {}
+        spec: null
         stepTemplate:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/environment/pullrequest.yaml@versionStream
           name: ""
           resources:
-            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 512Mi
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-env-pr.yaml@versionStream
+          name: ""
           resources: {}
-        - name: make-pr
+        - args:
+          - pr
+          command:
+          - make
+          envFrom:
+          - secretRef:
+              name: jx-boot-job-env-vars
+              optional: true
+          image: ghcr.io/jenkins-x/jx-boot:3.11.3
+          name: make-pr
           resources:
-            # override requests for the pod here
             requests:
-              cpu: 0.1
-              memory: 128Mi
+              cpu: 400m
+              memory: 512Mi
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 12h0m0s

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,7 +6,7 @@ environments:
 namespace: jx-staging
 repositories:
 - name: dev
-  url: https://docker-registry-jx.192.168.49.2.nip.io
+  url: oci://docker-registry-jx.192.168.49.2.nip.io/charts
 releases:
 - chart: dev/react-spring
   version: 0.0.74

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,7 +6,7 @@ environments:
 namespace: jx-staging
 repositories:
 - name: dev
-  url: https://docker-registry-jx.192.168.49.2.nip.io/v2/charts/react-spring/tags/list
+  url: http://docker-registry-jx.192.168.49.2.nip.io/v2/charts/react-spring/tags/list
 releases:
 - chart: dev/react-spring
   version: 0.0.74

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -7,9 +7,12 @@ namespace: jx-staging
 repositories:
 - name: dev
   url: https://iMckify.github.io/pipeline-config-charts/
+- name: dev2
+  url: http://bucketrepo-jx.192.168.49.2.nip.io
+  oci: true
 releases:
 - chart: dev/react-spring
-  version: 0.0.55
+  version: 0.0.74
   name: react-spring
   values:
   - jx-values.yaml

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,10 +6,7 @@ environments:
 namespace: jx-staging
 repositories:
 - name: dev
-  url: https://iMckify.github.io/pipeline-config-charts/
-- name: dev2
-  url: http://bucketrepo-jx.192.168.49.2.nip.io
-  oci: true
+  url: https://docker-registry-jx.192.168.49.2.nip.io
 releases:
 - chart: dev/react-spring
   version: 0.0.74

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,7 +6,7 @@ environments:
 namespace: jx-staging
 repositories:
 - name: dev
-  url: oci://docker-registry-jx.192.168.49.2.nip.io/charts
+  url: https://docker-registry-jx.192.168.49.2.nip.io/v2/charts/react-spring/tags/list
 releases:
 - chart: dev/react-spring
   version: 0.0.74


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.74

### Chores

* release 0.0.74 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* 5 helm push manual (Rokas Mockevičius)
