### PR TITLE
chore: promote react-spring to version 0.0.74

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -7,9 +7,12 @@ namespace: jx-production
 repositories:
 - name: dev
   url: https://iMckify.github.io/pipeline-config-charts/
+- name: dev2
+  url: http://bucketrepo-jx.192.168.49.2.nip.io
+  oci: true
 releases:
 - chart: dev/react-spring
-  version: 0.0.25
+  version: 0.0.74
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.74

### Chores

* release 0.0.74 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* 5 helm push manual (Rokas Mockevičius)
