### PR TITLE
chore: promote react-spring to version 0.0.76

### DIFF
--- a/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.75"
+    chart: "react-spring-0.0.76"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.75"
+        image: "10.97.57.112/imckify/react-spring:0.0.76"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.75
+          value: 0.0.76
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-production/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.75"
+    chart: "react-spring-0.0.76"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: 5548b1e72c6874d1a054fbbbf905f868b4f9840df672c75b52c568077edb3f7d
+        checksum/secret: 8f6744532209ecc41606537b636ad98b2780047d0d8d82e974f1bf7143d4ee68
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://iMckify.github.io/pipeline-config-charts/
 releases:
 - chart: dev/react-spring
-  version: 0.0.75
+  version: 0.0.76
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.76

### Chores

* release 0.0.76 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* redeploy (iMckify)
