### PR TITLE
chore: promote react-spring to version 0.0.77

### DIFF
--- a/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-react-spring-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: react-spring-react-spring
   labels:
     draft: draft-app
-    chart: "react-spring-0.0.76"
+    chart: "react-spring-0.0.77"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: react-spring-react-spring
       containers:
       - name: react-spring
-        image: "10.97.57.112/imckify/react-spring:0.0.76"
+        image: "10.97.57.112/imckify/react-spring:0.0.77"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.76
+          value: 0.0.77
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
+++ b/config-root/namespaces/jx-staging/react-spring/react-spring-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: react-spring
   labels:
-    chart: "react-spring-0.0.76"
+    chart: "react-spring-0.0.77"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'react-spring'

--- a/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
+++ b/config-root/namespaces/jx/docker-registry/docker-registry-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 492034f39a50c85107770255c8e115771feb08b03bd86989b039c405ed359257
-        checksum/secret: 8f6744532209ecc41606537b636ad98b2780047d0d8d82e974f1bf7143d4ee68
+        checksum/secret: e73c3dd7367014fae6e22ca3c6a2fdcf742d9b27a733156c52ff614a07936174
     spec:
       securityContext:
         fsGroup: 1000

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://iMckify.github.io/pipeline-config-charts/
 releases:
 - chart: dev/react-spring
-  version: 0.0.76
+  version: 0.0.77
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.77

### Chores

* release 0.0.77 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* minor fix gradle publish (iMckify)
* rename github pipeline config (iMckify)
* keep `/test pr` naming (iMckify)
* remove extra steps (iMckify)
* Revert "send to ngrok webhook (local server)" (iMckify)
* send to ngrok webhook (local server) (iMckify)
* imckify-webhook-event (iMckify)
* comment v5.2 (iMckify)
* comment v5 (iMckify)
* comment v4 (iMckify)
* comment v3 (iMckify)
* use manually created test_token PAT (iMckify)
* comment v2 (iMckify)
* fix commenting with new github setting and token (iMckify)
* fix commenting with new github setting (iMckify)
* fix commenting 2 (iMckify)
* fix commenting (iMckify)
* not always (iMckify)
* test (iMckify)
* trigger3 (iMckify)
* trigger2 (imckify)
* trigger (Rokas Mockevičius)
* action send custom event (Rokas Mockevičius)
* jx3 trigger (Rokas Mockevičius)
* Revert "gradle publish 2 fix jx build" (iMckify)
* publish.gradle refactor (iMckify)
* move to publish.gradle (iMckify)
* gradle publish 2 fix jx build (iMckify)
* gradle publish (iMckify)
* Revert "Revert "gradle publish in build workflow"" (iMckify)
* Revert "actions/upload-artifact@v4" (iMckify)
* actions/upload-artifact@v4 (iMckify)
* Revert "gradle publish in build workflow" (iMckify)
* gradle publish in build workflow (iMckify)
* Create build.yml (Rokas Mockevičius)
