### PR TITLE
chore: promote react-spring to version 0.0.77

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://iMckify.github.io/pipeline-config-charts/
 releases:
 - chart: dev/react-spring
-  version: 0.0.76
+  version: 0.0.77
   name: react-spring
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# react-spring

## Changes in version 0.0.77

### Chores

* release 0.0.77 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* minor fix gradle publish (iMckify)
* rename github pipeline config (iMckify)
* keep `/test pr` naming (iMckify)
* remove extra steps (iMckify)
* Revert "send to ngrok webhook (local server)" (iMckify)
* send to ngrok webhook (local server) (iMckify)
* imckify-webhook-event (iMckify)
* comment v5.2 (iMckify)
* comment v5 (iMckify)
* comment v4 (iMckify)
* comment v3 (iMckify)
* use manually created test_token PAT (iMckify)
* comment v2 (iMckify)
* fix commenting with new github setting and token (iMckify)
* fix commenting with new github setting (iMckify)
* fix commenting 2 (iMckify)
* fix commenting (iMckify)
* not always (iMckify)
* test (iMckify)
* trigger3 (iMckify)
* trigger2 (imckify)
* trigger (Rokas Mockevičius)
* action send custom event (Rokas Mockevičius)
* jx3 trigger (Rokas Mockevičius)
* Revert "gradle publish 2 fix jx build" (iMckify)
* publish.gradle refactor (iMckify)
* move to publish.gradle (iMckify)
* gradle publish 2 fix jx build (iMckify)
* gradle publish (iMckify)
* Revert "Revert "gradle publish in build workflow"" (iMckify)
* Revert "actions/upload-artifact@v4" (iMckify)
* actions/upload-artifact@v4 (iMckify)
* Revert "gradle publish in build workflow" (iMckify)
* gradle publish in build workflow (iMckify)
* Create build.yml (Rokas Mockevičius)
